### PR TITLE
[2024/07/21]feat/#13 signup

### DIFF
--- a/src/main/java/com/sparta/mypet/common/entity/GlobalMessage.java
+++ b/src/main/java/com/sparta/mypet/common/entity/GlobalMessage.java
@@ -12,11 +12,17 @@ public enum GlobalMessage {
 	MSG_NOT_FOUND("요청한 리소스를 찾을 수 없습니다."),
 	MSG_INTERNAL_SERVER_ERROR("서버 오류가 발생했습니다."),
 	MSG_CONFLICT("이미 존재하는 항목입니다."),
-	MSG_UNAUTHORIZED("요청에 대해 인증을 실패했습니다.");
+	MSG_UNAUTHORIZED("요청에 대해 인증을 실패했습니다."),
+	ERROR_MESSAGE_PREFIX("Exception caught: "),
 
 	// 응답 메시지
+	// User
+	CREATE_USER_SUCCESS("회원가입이 성공적으로 완료되었습니다."),
 
 	// 에러 메세지
+	// User
+	USER_EMAIL_DUPLICATE("이미 존재하는 이메일입니다."),
+	PASSWORD_INVALID("비밀번호가 일치하지 않습니다.");
 
 	private final String message;
 

--- a/src/main/java/com/sparta/mypet/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/mypet/common/exception/GlobalExceptionHandler.java
@@ -5,13 +5,18 @@ import java.util.stream.Collectors;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
 import com.sparta.mypet.common.dto.MessageResponseDto;
+import com.sparta.mypet.common.entity.GlobalMessage;
+import com.sparta.mypet.common.exception.auth.PasswordInvalidException;
+import com.sparta.mypet.common.exception.auth.UserEmailDuplicateException;
 import com.sparta.mypet.common.util.ResponseFactory;
 
 import jakarta.validation.ConstraintViolationException;
 
+@ControllerAdvice
 public class GlobalExceptionHandler {
 
 	/**
@@ -50,8 +55,25 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(IllegalArgumentException.class)
 	public ResponseEntity<MessageResponseDto> illegalArgumentExceptionHandler(IllegalArgumentException e) {
 
-		String errorMessage = "Exception caught: " + e.getMessage();
+		String errorMessage = GlobalMessage.ERROR_MESSAGE_PREFIX.getMessage() + e.getMessage();
 
 		return ResponseFactory.badRequest(errorMessage);
 	}
+
+	@ExceptionHandler(UserEmailDuplicateException.class)
+	public ResponseEntity<MessageResponseDto> userEmailDuplicateExceptionHandler(UserEmailDuplicateException e) {
+
+		String errorMessage = GlobalMessage.ERROR_MESSAGE_PREFIX.getMessage() + e.getMessage();
+
+		return ResponseFactory.conflictError(errorMessage);
+	}
+
+	@ExceptionHandler(PasswordInvalidException.class)
+	public ResponseEntity<MessageResponseDto> passwordInvalidExceptionHandler(PasswordInvalidException e) {
+
+		String errorMessage = GlobalMessage.ERROR_MESSAGE_PREFIX.getMessage() + e.getMessage();
+
+		return ResponseFactory.authorizedError(errorMessage);
+	}
+
 }

--- a/src/main/java/com/sparta/mypet/common/exception/auth/PasswordInvalidException.java
+++ b/src/main/java/com/sparta/mypet/common/exception/auth/PasswordInvalidException.java
@@ -1,0 +1,14 @@
+package com.sparta.mypet.common.exception.auth;
+
+import com.sparta.mypet.common.entity.GlobalMessage;
+
+public class PasswordInvalidException extends RuntimeException {
+
+	public PasswordInvalidException(String message) {
+		super(message);
+	}
+
+	public PasswordInvalidException(GlobalMessage errorMessage) {
+		super(errorMessage.getMessage());
+	}
+}

--- a/src/main/java/com/sparta/mypet/common/exception/auth/UserEmailDuplicateException.java
+++ b/src/main/java/com/sparta/mypet/common/exception/auth/UserEmailDuplicateException.java
@@ -1,0 +1,14 @@
+package com.sparta.mypet.common.exception.auth;
+
+import com.sparta.mypet.common.entity.GlobalMessage;
+
+public class UserEmailDuplicateException extends RuntimeException {
+
+	public UserEmailDuplicateException(String message) {
+		super(message);
+	}
+
+	public UserEmailDuplicateException(GlobalMessage errorMessage) {
+		super(errorMessage.getMessage());
+	}
+}

--- a/src/main/java/com/sparta/mypet/common/initialization/DataInitialization.java
+++ b/src/main/java/com/sparta/mypet/common/initialization/DataInitialization.java
@@ -1,0 +1,50 @@
+package com.sparta.mypet.common.initialization;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import com.sparta.mypet.domain.auth.UserRepository;
+import com.sparta.mypet.domain.auth.entity.User;
+import com.sparta.mypet.domain.auth.entity.UserRole;
+import com.sparta.mypet.domain.auth.entity.UserStatus;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j(topic = "Initialization")
+@Component
+@RequiredArgsConstructor
+public class DataInitialization implements CommandLineRunner {
+
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	@Value("${admin-user-email}")
+	String adminEmail;
+
+	@Value("${admin-user-password}")
+	String adminPassword;
+
+	@Override
+	public void run(String... args) {
+		if(userRepository.count() == 0) {
+
+			String encodePassword = passwordEncoder.encode(adminPassword);
+			String nickname = "MyPetAdmin";
+
+			User user = User.builder()
+				.email(adminEmail)
+				.password(encodePassword)
+				.nickname(nickname)
+				.penaltyCount(0)
+				.role(UserRole.ADMIN)
+				.status(UserStatus.ACTIVE)
+				.build();
+
+			userRepository.save(user);
+			log.info("관리자 계정 생성!");
+		}
+	}
+}

--- a/src/main/java/com/sparta/mypet/domain/auth/UserController.java
+++ b/src/main/java/com/sparta/mypet/domain/auth/UserController.java
@@ -1,0 +1,33 @@
+package com.sparta.mypet.domain.auth;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sparta.mypet.common.dto.DataResponseDto;
+import com.sparta.mypet.common.entity.GlobalMessage;
+import com.sparta.mypet.common.util.ResponseFactory;
+import com.sparta.mypet.domain.auth.dto.SignupRequestDto;
+import com.sparta.mypet.domain.auth.dto.SignupResponseDto;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class UserController {
+
+	private final UserService userService;
+
+	@PostMapping("/users")
+	public ResponseEntity<DataResponseDto<SignupResponseDto>> signup(@Valid @RequestBody SignupRequestDto requestDto) {
+
+		SignupResponseDto responseDto = userService.signup(requestDto);
+
+		return ResponseFactory.created(responseDto, GlobalMessage.CREATE_USER_SUCCESS.getMessage());
+	}
+
+}

--- a/src/main/java/com/sparta/mypet/domain/auth/UserRepository.java
+++ b/src/main/java/com/sparta/mypet/domain/auth/UserRepository.java
@@ -1,8 +1,13 @@
 package com.sparta.mypet.domain.auth;
 
-import com.sparta.mypet.domain.auth.entity.User;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import com.sparta.mypet.domain.auth.entity.User;
+
+@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+	Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/sparta/mypet/domain/auth/UserService.java
+++ b/src/main/java/com/sparta/mypet/domain/auth/UserService.java
@@ -1,0 +1,55 @@
+package com.sparta.mypet.domain.auth;
+
+import java.util.Optional;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import com.sparta.mypet.common.entity.GlobalMessage;
+import com.sparta.mypet.common.exception.auth.PasswordInvalidException;
+import com.sparta.mypet.common.exception.auth.UserEmailDuplicateException;
+import com.sparta.mypet.domain.auth.dto.SignupRequestDto;
+import com.sparta.mypet.domain.auth.dto.SignupResponseDto;
+import com.sparta.mypet.domain.auth.entity.User;
+import com.sparta.mypet.domain.auth.entity.UserRole;
+import com.sparta.mypet.domain.auth.entity.UserStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	public SignupResponseDto signup(SignupRequestDto requestDto) {
+
+		Optional<User> duplicateUser = userRepository.findByEmail(requestDto.getEmail());
+
+		if (duplicateUser.isPresent()) {
+			throw new UserEmailDuplicateException(GlobalMessage.USER_EMAIL_DUPLICATE);
+		}
+
+		if (!requestDto.getPassword().equals(requestDto.getRepeatPassword())) {
+			throw new PasswordInvalidException(GlobalMessage.PASSWORD_INVALID);
+		}
+
+		String encodePassword = passwordEncoder.encode(requestDto.getPassword());
+
+		User user = User.builder()
+			.email(requestDto.getEmail())
+			.password(encodePassword)
+			.nickname(requestDto.getNickname())
+			.penaltyCount(0)
+			.role(UserRole.USER)
+			.status(UserStatus.ACTIVE)
+			.build();
+
+		User saveUser = userRepository.save(user);
+
+		return SignupResponseDto.builder()
+			.user(saveUser)
+			.build();
+	}
+}

--- a/src/main/java/com/sparta/mypet/domain/auth/config/PasswordConfig.java
+++ b/src/main/java/com/sparta/mypet/domain/auth/config/PasswordConfig.java
@@ -1,0 +1,15 @@
+package com.sparta.mypet.domain.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+}

--- a/src/main/java/com/sparta/mypet/domain/auth/dto/SignupRequestDto.java
+++ b/src/main/java/com/sparta/mypet/domain/auth/dto/SignupRequestDto.java
@@ -1,0 +1,29 @@
+package com.sparta.mypet.domain.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class SignupRequestDto {
+
+	@NotBlank(message = "이메일은 공백일 수 없습니다.")
+	@Size(min = 10, max = 50, message = "이메일은 글자 수는 10자에서 50자 사이여야 합니다.")
+	@Email(message = "올바른 이메일 형식을 입력하세요.")
+	private String email;
+
+	@NotBlank(message = "비밀번호는 공백일 수 없습니다.")
+	@Size(min = 8, max = 15, message = "비밀번호는 8자에서 15자 사이여야 합니다.")
+	@Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]*$", message = "비밀번호는 반드시 한 가지 이상의 대문자, 소문자, 숫자, 특수문자를 포함해야합니다.")
+	private String password;
+
+	@NotBlank(message = "비밀번호는 공백일 수 없습니다.")
+	@Size(min = 8, max = 15, message = "비밀번호는 8자에서 15자 사이여야 합니다.")
+	@Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]*$", message = "비밀번호는 반드시 한 가지 이상의 대문자, 소문자, 숫자, 특수문자를 포함해야합니다.")
+	private String repeatPassword;
+
+	@NotBlank(message = "이름은 공백일 수 없습니다.")
+	private String nickname;
+}

--- a/src/main/java/com/sparta/mypet/domain/auth/dto/SignupResponseDto.java
+++ b/src/main/java/com/sparta/mypet/domain/auth/dto/SignupResponseDto.java
@@ -1,0 +1,18 @@
+package com.sparta.mypet.domain.auth.dto;
+
+import com.sparta.mypet.domain.auth.entity.User;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class SignupResponseDto {
+	private final String email;
+	private final String nickname;
+
+	@Builder
+	public SignupResponseDto(User user) {
+		this.email = user.getEmail();
+		this.nickname = user.getNickname();
+	}
+}

--- a/src/main/java/com/sparta/mypet/domain/auth/entity/User.java
+++ b/src/main/java/com/sparta/mypet/domain/auth/entity/User.java
@@ -25,16 +25,16 @@ public class User extends Timestamped {
 	@Column(name = "user_id")
 	private Long id;
 
-	@Column(nullable = false)
+	@Column(nullable = false, unique = true)
 	private String email;
 
 	@Column(nullable = false)
 	private String password;
 
-	@Column(name = "username", nullable = false)
-	private String userName;
-
 	@Column(nullable = false)
+	private String nickname;
+
+	@Column(name = "penalty_count", nullable = false)
 	private Integer penaltyCount;
 
 	@Column
@@ -42,20 +42,20 @@ public class User extends Timestamped {
 
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
-	private UserRoleEnum role;
+	private UserRole role;
 
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
-	private UserStatusEnum status;
+	private UserStatus status;
 
 	@Builder
-	public User(String email, String password, String userName, Integer penaltyCount, UserRoleEnum role, UserStatusEnum status) {
+	public User(String email, String password, String nickname, Integer penaltyCount, UserRole role,
+		UserStatus status) {
 		this.email = email;
 		this.password = password;
-		this.userName = userName;
+		this.nickname = nickname;
 		this.penaltyCount = penaltyCount;
 		this.role = role;
 		this.status = status;
 	}
-
 }

--- a/src/main/java/com/sparta/mypet/domain/auth/entity/UserRole.java
+++ b/src/main/java/com/sparta/mypet/domain/auth/entity/UserRole.java
@@ -1,21 +1,20 @@
 package com.sparta.mypet.domain.auth.entity;
 
-public enum UserRoleEnum {
+import lombok.Getter;
+
+@Getter
+public enum UserRole {
 	USER(Authority.USER),  // 사용자 권한
 	ADMIN(Authority.ADMIN),  // 관리자 권한
 	MANAGER(Authority.MANAGER); // 매니저 권한
 
 	private final String authority;
 
-	UserRoleEnum(String authority) {
+	UserRole(String authority) {
 		this.authority = authority;
 	}
 
-	public String getAuthority() {
-		return this.authority;
-	}
-
-	public static class Authority {
+	private static class Authority {
 		public static final String USER = "ROLE_USER";
 		public static final String ADMIN = "ROLE_ADMIN";
 		public static final String MANAGER = "ROLE_MANAGER";

--- a/src/main/java/com/sparta/mypet/domain/auth/entity/UserStatus.java
+++ b/src/main/java/com/sparta/mypet/domain/auth/entity/UserStatus.java
@@ -1,6 +1,6 @@
 package com.sparta.mypet.domain.auth.entity;
 
-public enum UserStatusEnum {
+public enum UserStatus {
 	ACTIVE, //활성화
 	SUSPENDED, //중지
 	BAN //영구 중지

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,6 @@ spring.jpa.defer-datasource-initialization=true
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.use_sql_comments=true
+# admin user email, password
+admin-user-email=${ADMIN_EMAIL}
+admin-user-password=${ADMIN_PASSWORD}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.application.name= Mypet
+spring.application.name=Mypet
 spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
@@ -7,7 +7,7 @@ spring.jpa.show-sql=true
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 # create, update, none, creat-drop
 spring.jpa.database=mysql
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.defer-datasource-initialization=true
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#13 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- signup 기능 구현

- admin 계정 생성

### 스크린샷 (선택)

- 회원가입 성공
![image](https://github.com/user-attachments/assets/3a549fa4-2769-43f1-a245-a3e4d51eba08)

- 회원가입 실패(이메일 중복, 반복 비밀번호 불일치)
![image](https://github.com/user-attachments/assets/982f0bcd-6834-48e0-8b27-4e1695ffd5e3)
![image](https://github.com/user-attachments/assets/acdfe227-de11-4c4e-9a5a-be87c36c9b74)

- ADMIN 계정 생성
![image](https://github.com/user-attachments/assets/0f04b33c-7e78-413a-9c6c-515d1bd5a815)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

공통으로 사용되는 `GlobalMessage`가 많이 충돌 날 것 같습니다! PULL이나 MERGE 할 때, 한번씩 더 확인 부탁드려요!
DB 세팅이 `create`로 되어 있어서 `update`로 수정했습니다.
admin 유저의 이메일과 패스워드는 슬랙으로 공유하겠습니다.
