### PR TITLE
[2024/07/23]feat/#28 logout

### DIFF
--- a/http/user.http
+++ b/http/user.http
@@ -28,3 +28,7 @@ Content-Type: application/json
 POST /api/auth/logout HTTP/1.1
 Host: {{root-path}}
 Authorization: {{Authorization}}
+
+> {%
+    client.global.set("Authorization", "");
+%}

--- a/http/user.http
+++ b/http/user.http
@@ -23,3 +23,8 @@ Content-Type: application/json
 > {%
     client.global.set("Authorization", response.headers.valueOf("Authorization"));
 %}
+
+### 로그아웃
+POST /api/auth/logout HTTP/1.1
+Host: {{root-path}}
+Authorization: {{Authorization}}

--- a/src/main/java/com/sparta/mypet/common/entity/GlobalMessage.java
+++ b/src/main/java/com/sparta/mypet/common/entity/GlobalMessage.java
@@ -19,6 +19,7 @@ public enum GlobalMessage {
 	// User
 	CREATE_USER_SUCCESS("회원가입이 성공적으로 완료되었습니다."),
 	LOGIN_SUCCESS("로그인이 성공적으로 완료되었습니다."),
+	LOGOUT_SUCCESS("로그아웃이 성공적으로 완료되었습니다."),
 
 	// 에러 메세지
 	// User

--- a/src/main/java/com/sparta/mypet/domain/auth/AuthController.java
+++ b/src/main/java/com/sparta/mypet/domain/auth/AuthController.java
@@ -3,10 +3,12 @@ package com.sparta.mypet.domain.auth;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.sparta.mypet.common.dto.DataResponseDto;
+import com.sparta.mypet.common.dto.MessageResponseDto;
 import com.sparta.mypet.common.entity.GlobalMessage;
 import com.sparta.mypet.common.util.ResponseFactory;
 import com.sparta.mypet.domain.auth.dto.LoginRequestDto;
@@ -25,6 +27,14 @@ public class AuthController {
 		String token = authService.login(requestDto);
 
 		return ResponseFactory.ok(token, GlobalMessage.LOGIN_SUCCESS.getMessage());
+	}
+
+	@PostMapping("/auth/logout")
+	public ResponseEntity<MessageResponseDto> logout(@RequestHeader(value = "Authorization") String token) {
+
+		authService.logout(token);
+
+		return ResponseFactory.ok(GlobalMessage.LOGOUT_SUCCESS.getMessage());
 	}
 
 }

--- a/src/main/java/com/sparta/mypet/domain/auth/UserService.java
+++ b/src/main/java/com/sparta/mypet/domain/auth/UserService.java
@@ -2,6 +2,7 @@ package com.sparta.mypet.domain.auth;
 
 import java.util.Optional;
 
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -51,5 +52,11 @@ public class UserService {
 		return SignupResponseDto.builder()
 			.user(saveUser)
 			.build();
+	}
+
+	public User findUserByEmail(String email) {
+		return userRepository.findByEmail(email).orElseThrow(
+			() -> new UsernameNotFoundException(GlobalMessage.USER_EMAIL_NOT_FOUND.getMessage())
+		);
 	}
 }

--- a/src/main/java/com/sparta/mypet/security/JwtService.java
+++ b/src/main/java/com/sparta/mypet/security/JwtService.java
@@ -164,4 +164,21 @@ public class JwtService {
 			.get(JwtConfig.AUTHORIZATION_KEY);
 	}
 
+	/**
+	 * Refresh 토큰 쿠키를 삭제합니다.
+	 */
+	public void deleteRefreshTokenAtCookie() {
+		// 덮어 쓰기
+		Cookie cookie = new Cookie(JwtConfig.REFRESH_TOKEN_COOKIE_NAME, null);
+		cookie.setHttpOnly(true);
+		cookie.setSecure(true);
+		cookie.setPath("/");
+		cookie.setMaxAge(0); // 쿠키 시간 초기화
+		HttpServletResponse response = ((ServletRequestAttributes)Objects.requireNonNull(
+			RequestContextHolder.getRequestAttributes())).getResponse();
+
+		if (response != null) {
+			response.addCookie(cookie);
+		}
+	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#28 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 로그아웃 기능 구현

- 공통으로 많이 쓰이는 findByEmail UserService에 메서드화

### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/a4ceb7b7-4357-4bb9-9eb1-8a8d9a098698)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

현재 로그아웃에는 클라이언트의 refresh token cookie만 클리어해주고,
 access token 을 클리어해주는 기능을 프론트에서 진행할 예정입니다.