### PR TITLE
[2024/08/02]feat/#101 suspension logic

### DIFF
--- a/http/backoffice.http
+++ b/http/backoffice.http
@@ -17,14 +17,25 @@ GET /api/admin/user-manage HTTP/1.1
 Host: {{root-path}}
 Authorization: {{Authorization}}
 
-### 유저 상태 변경
+### 유저 상태 변경 - 정지제외
 PUT /api/admin/user-manage/{{userId}}/status HTTP/1.1
 Host: {{root-path}}
 Content-Type: application/json
 Authorization: {{Authorization}}
 
 {
-  "status": "BAN"
+  "status": "ACTIVE"
+}
+
+### 유저 상태 변경 - 정지
+PUT /api/admin/user-manage/{{userId}}/status HTTP/1.1
+Host: {{root-path}}
+Content-Type: application/json
+Authorization: {{Authorization}}
+
+{
+  "status": "SUSPENSION",
+  "suspensionIssue": "그냥!"
 }
 
 ### 유저 권한 변경

--- a/src/main/java/com/sparta/mypet/domain/auth/entity/User.java
+++ b/src/main/java/com/sparta/mypet/domain/auth/entity/User.java
@@ -26,36 +26,28 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class User extends Timestamped {
 
+	@OneToMany(mappedBy = "user", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+	private final List<Post> postList = new ArrayList<>();
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "user_id")
 	private Long id;
-
 	@Column(nullable = false, unique = true)
 	private String email;
-
 	@Column(nullable = false)
 	private String password;
-
 	@Column(nullable = false)
 	private String nickname;
-
 	@Column(name = "suspension_count", nullable = false)
 	private Integer suspensionCount;
-
 	@Column
 	private String refreshToken;
-
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
 	private UserRole role;
-
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
 	private UserStatus status;
-
-	@OneToMany(mappedBy = "user", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
-	private final List<Post> postList = new ArrayList<>();
 
 	@Builder
 	public User(String email, String password, String nickname, Integer suspensionCount, UserRole role,
@@ -90,5 +82,10 @@ public class User extends Timestamped {
 
 	public void addPost(Post post) {
 		this.postList.add(post);
+	}
+
+	public void updateSuspendUser(int newPenaltyCount) {
+		this.status = UserStatus.SUSPENSION;
+		this.suspensionCount = newPenaltyCount;
 	}
 }

--- a/src/main/java/com/sparta/mypet/domain/backoffice/BackOfficeController.java
+++ b/src/main/java/com/sparta/mypet/domain/backoffice/BackOfficeController.java
@@ -43,8 +43,10 @@ public class BackOfficeController {
 
 	@PutMapping("/user-manage/{userId}/status")
 	public ResponseEntity<DataResponseDto<UserStatusResponseDto>> updateUserStatus(
+		@AuthenticationPrincipal UserDetailsImpl userDetails,
 		@Valid @RequestBody UserStatusRequestDto requestDto, @PathVariable Long userId) {
-		UserStatusResponseDto responseDto = backOfficeService.updateUserStatus(requestDto, userId);
+		UserStatusResponseDto responseDto = backOfficeService.updateUserStatus(userDetails.getUser(), requestDto,
+			userId);
 		return ResponseFactory.ok(responseDto, "사용자 상태 변경 성공");
 	}
 

--- a/src/main/java/com/sparta/mypet/domain/backoffice/BackOfficeService.java
+++ b/src/main/java/com/sparta/mypet/domain/backoffice/BackOfficeService.java
@@ -20,6 +20,7 @@ import com.sparta.mypet.domain.backoffice.dto.UserStatusResponseDto;
 import com.sparta.mypet.domain.report.ReportService;
 import com.sparta.mypet.domain.report.entity.Report;
 import com.sparta.mypet.domain.report.entity.ReportStatus;
+import com.sparta.mypet.domain.suspension.SuspensionService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -29,6 +30,7 @@ public class BackOfficeService {
 
 	private final UserService userService;
 	private final ReportService reportService;
+	private final SuspensionService suspensionService;
 
 	@Transactional(readOnly = true)
 	public Page<UserListResponseDto> getUsers(int page, int pageSize, String sortBy) {
@@ -40,10 +42,13 @@ public class BackOfficeService {
 	}
 
 	@Transactional
-	public UserStatusResponseDto updateUserStatus(UserStatusRequestDto requestDto, Long userId) {
+	public UserStatusResponseDto updateUserStatus(User handleUser, UserStatusRequestDto requestDto, Long userId) {
 		User updatedUser = userService.findUserById(userId);
 		UserStatus userStatus = UserStatus.valueOf(requestDto.getStatus());
 
+		if (userStatus.equals(UserStatus.SUSPENSION)) {
+			suspensionService.processReports(requestDto.getSuspensionIssue(), updatedUser, handleUser);
+		}
 		updatedUser.updateUserStatus(userStatus);
 
 		return new UserStatusResponseDto(updatedUser);

--- a/src/main/java/com/sparta/mypet/domain/backoffice/dto/UserStatusRequestDto.java
+++ b/src/main/java/com/sparta/mypet/domain/backoffice/dto/UserStatusRequestDto.java
@@ -7,4 +7,5 @@ import lombok.Getter;
 public class UserStatusRequestDto {
 	@NotBlank(message = "상태값을 선택해주세요.")
 	private String status;
+	private String suspensionIssue;
 }

--- a/src/main/java/com/sparta/mypet/domain/post/PostRepository.java
+++ b/src/main/java/com/sparta/mypet/domain/post/PostRepository.java
@@ -1,10 +1,14 @@
 package com.sparta.mypet.domain.post;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.sparta.mypet.domain.post.entity.Category;
 import com.sparta.mypet.domain.post.entity.Post;
@@ -21,6 +25,21 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
 	Page<Post> findByCategoryAndPostStatus(Category category, PostStatus status, Pageable pageable);
 
-	@Query("SELECT p FROM Post p WHERE p.user.email = :email AND p.postStatus = :postStatus" )
-	Page<Post> findByUserName(@Param("email") String email, @Param("postStatus") PostStatus postStatus, Pageable pageable);
+	@Query("SELECT p FROM Post p WHERE p.user.email = :email AND p.postStatus = :postStatus")
+	Page<Post> findByUserName(@Param("email") String email, @Param("postStatus") PostStatus postStatus,
+		Pageable pageable);
+
+	@Query(value = "SELECT p.post_id " +
+		"FROM reports r " +
+		"LEFT JOIN posts p ON r.reported_post_id = p.post_id " +
+		"WHERE p.user_id = :userId",
+		nativeQuery = true)
+	List<Long> findReportedPostIdsByUserId(@Param("userId") Long userId);
+
+	@Modifying
+	@Transactional
+	@Query("UPDATE Post p SET p.postStatus = :status WHERE p.id IN :postIds AND p.id NOT IN " +
+		"(SELECT r.reportedPost.id FROM Report r WHERE r.reportStatus = 'REJECTED')")
+	void updatePostStatus(@Param("status") PostStatus status, @Param("postIds") List<Long> postIds);
+
 }

--- a/src/main/java/com/sparta/mypet/domain/post/PostService.java
+++ b/src/main/java/com/sparta/mypet/domain/post/PostService.java
@@ -31,10 +31,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PostService {
 
+	private static final int MAX_FILE_COUNT = 5;
 	private final PostRepository postRepository;
 	private final FileService fileService;
 	private final UserService userService;
-	private static final int MAX_FILE_COUNT = 5;
 
 	@Transactional
 	public PostResponseDto createPost(String email, PostRequestDto requestDto, String category,
@@ -171,5 +171,15 @@ public class PostService {
 	public boolean isLikePost(User user, Long postId) {
 		Post post = findPostById(postId);
 		return post.isLikedByUser(user);
+	}
+
+	public void updateReportedPostsStatusByUserId(Long userId, PostStatus status) {
+		// 리포트된 게시물의 ID를 조회합니다.
+		List<Long> postIds = postRepository.findReportedPostIdsByUserId(userId);
+
+		if (!postIds.isEmpty()) {
+			// 조회된 게시물의 상태를 업데이트합니다.
+			postRepository.updatePostStatus(status, postIds);
+		}
 	}
 }

--- a/src/main/java/com/sparta/mypet/domain/post/entity/Post.java
+++ b/src/main/java/com/sparta/mypet/domain/post/entity/Post.java
@@ -26,7 +26,6 @@ import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Table(name = "posts")
 @Entity
@@ -34,40 +33,31 @@ import lombok.Setter;
 @NoArgsConstructor
 public class Post extends Timestamped {
 
+	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+	private final List<Comment> comments = new ArrayList<>();
+	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+	private final List<Like> likes = new ArrayList<>();
+	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+	private final List<File> files = new ArrayList<>();
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "post_id")
 	private Long id;
-
 	@Column(nullable = false)
 	private String postTitle;
-
 	@Column(nullable = false)
 	private String postContent;
-
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
 	private Category category;
-
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
 	private PostStatus postStatus;
-
 	@ManyToOne(fetch = FetchType.EAGER)
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
-
 	@Column(nullable = false)
 	private Long likeCount;
-
-	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-	private final List<Comment> comments = new ArrayList<>();
-
-	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-	private final List<Like> likes = new ArrayList<>();
-
-	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-	private final List<File> files = new ArrayList<>();
 
 	@Builder
 	public Post(String postContent, String postTitle, Category category, User user, Long likeCount) {
@@ -106,4 +96,7 @@ public class Post extends Timestamped {
 		return likes.stream().anyMatch(like -> like.getUser().equals(user));
 	}
 
+	public void updatePostStatus(PostStatus postStatus) {
+		this.postStatus = postStatus;
+	}
 }

--- a/src/main/java/com/sparta/mypet/domain/report/ReportRepository.java
+++ b/src/main/java/com/sparta/mypet/domain/report/ReportRepository.java
@@ -3,11 +3,26 @@ package com.sparta.mypet.domain.report;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.sparta.mypet.domain.report.entity.Report;
 
+import io.lettuce.core.dynamic.annotation.Param;
+
 @Repository
 public interface ReportRepository extends JpaRepository<Report, Long> {
 	Optional<Report> findByReportedPost_IdAndReporterUserId(Long reportedPostId, Long reporterUserId);
+
+	@Modifying
+	@Query(value = "UPDATE reports r "
+		+ "JOIN posts p ON r.reported_post_id = p.post_id "
+		+ "SET r.report_status = 'COMPLETED', "
+		+ "    r.handle_user_id = :handleUserId "
+		+ "WHERE r.report_status IN ('PENDING', 'IN_PROGRESS') "
+		+ "  AND p.user_id = :userId",
+		nativeQuery = true)
+	void markReportsAsCompletedAndSetHandleUser(@Param("userId") Long userId, @Param("handleUserId") Long handleUserId);
+
 }

--- a/src/main/java/com/sparta/mypet/domain/report/ReportService.java
+++ b/src/main/java/com/sparta/mypet/domain/report/ReportService.java
@@ -69,4 +69,9 @@ public class ReportService {
 		return reportRepository.findById(id).orElseThrow(() ->
 			new ReportNotFoundException(GlobalMessage.REPORT_NOT_FOUND.getMessage()));
 	}
+
+	public void markReportsAsCompletedAndSetHandleUser(Long reportedUserId, Long handleUserId) {
+		reportRepository.markReportsAsCompletedAndSetHandleUser(reportedUserId, handleUserId);
+	}
+
 }

--- a/src/main/java/com/sparta/mypet/domain/suspension/SuspensionRepository.java
+++ b/src/main/java/com/sparta/mypet/domain/suspension/SuspensionRepository.java
@@ -1,0 +1,9 @@
+package com.sparta.mypet.domain.suspension;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.sparta.mypet.domain.suspension.entity.Suspension;
+
+public interface SuspensionRepository extends JpaRepository<Suspension, Long> {
+
+}

--- a/src/main/java/com/sparta/mypet/domain/suspension/SuspensionService.java
+++ b/src/main/java/com/sparta/mypet/domain/suspension/SuspensionService.java
@@ -1,0 +1,64 @@
+package com.sparta.mypet.domain.suspension;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sparta.mypet.domain.auth.entity.User;
+import com.sparta.mypet.domain.post.PostService;
+import com.sparta.mypet.domain.post.entity.PostStatus;
+import com.sparta.mypet.domain.report.ReportService;
+import com.sparta.mypet.domain.suspension.entity.Suspension;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SuspensionService {
+
+	private final ReportService reportService;
+	private final PostService postService;
+	private final SuspensionRepository suspensionRepository;
+
+	@Transactional
+	public void processReports(String suspensionIssue, User user, User handleUser) {
+		int suspensionCount = user.getSuspensionCount();
+
+		suspendUser(user, suspensionCount, suspensionIssue, handleUser);
+	}
+
+	private void suspendUser(User user, int currentSuspensionCount, String suspensionIssue, User handleUser) {
+		int newSuspensionCount = currentSuspensionCount + 1;
+
+		int suspensionDays = getSuspensionDays(newSuspensionCount);
+		LocalDateTime suspensionEndDatetime = LocalDateTime.now().plusDays(suspensionDays);
+
+		//유저 상태 변경 및 count 변경
+		user.updateSuspendUser(newSuspensionCount);
+		//해당 user의 Report 상태가 Pending이나 in_progress인 경우 completed로 바꾸고, handleuser는 status 변경하는 관리자로 지정
+		reportService.markReportsAsCompletedAndSetHandleUser(user.getId(), handleUser.getId());
+		//report 반려상태가 아닌 post의 status를 inactive 상태로 변경
+		postService.updateReportedPostsStatusByUserId(user.getId(), PostStatus.INACTIVE);
+
+		Suspension suspension = Suspension.builder().
+			suspensionHandleUserId(handleUser.getId()).
+			suspensionIssue(suspensionIssue).
+			user(user).
+			suspensionStartDatetime(LocalDateTime.now()).
+			suspensionEndDatetime(suspensionEndDatetime).build();
+
+		suspensionRepository.save(suspension);
+	}
+
+	private int getSuspensionDays(int suspensionCount) {
+		return switch (suspensionCount) {
+			case 1 -> 3;
+			case 2 -> 7;
+			case 3 -> 30;
+			case 4 -> 36500; //약 100년으로 영구정지화 시킴.
+			default -> throw new IllegalArgumentException("Invalid penalty count");
+		};
+	}
+
+}

--- a/src/main/java/com/sparta/mypet/domain/suspension/entity/Suspension.java
+++ b/src/main/java/com/sparta/mypet/domain/suspension/entity/Suspension.java
@@ -1,0 +1,55 @@
+package com.sparta.mypet.domain.suspension.entity;
+
+import java.time.LocalDateTime;
+
+import com.sparta.mypet.domain.auth.entity.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "suspensions")
+@Entity
+@Getter
+@NoArgsConstructor
+public class Suspension {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "suspension_id")
+	private Long id;
+
+	@Column
+	private Long suspensionHandleUserId;
+
+	@Column(nullable = false)
+	private String suspensionIssue;
+
+	@Column(nullable = false)
+	private LocalDateTime suspensionStartDatetime;
+
+	@Column(nullable = false)
+	private LocalDateTime suspensionEndDatetime;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user; //신고를 당한 유저
+
+	@Builder
+	public Suspension(Long suspensionHandleUserId, String suspensionIssue, LocalDateTime suspensionStartDatetime,
+		LocalDateTime suspensionEndDatetime, User user) {
+		this.suspensionHandleUserId = suspensionHandleUserId;
+		this.suspensionIssue = suspensionIssue;
+		this.suspensionStartDatetime = suspensionStartDatetime;
+		this.suspensionEndDatetime = suspensionEndDatetime;
+		this.user = user;
+	}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#101 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

1. 유저 정지는 backoffice 의 유저 상태 변경에서만 가능하다.
2. 유저의 상태를 정지로 바꾸기 위해서는 suspensionIssue가 필요하다.
3. 유저의 상태는 suspension으로 변경하면
   3-1. user의 상태가 suspension으로 변경
   3-2. user의 suspension_count가 1증가
   3-3. report의 상태가 rejected가 아닌경우 completed로 변경
   3-4. 신고받은 post의 경우 rejected가 아닌 경우 inactive 상태로 변경
   3-5. suspension table에 row 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
