### PR TITLE
[2024/08/07] feat/#135 user reactive schedule

### DIFF
--- a/src/main/java/com/sparta/mypet/MypetApplication.java
+++ b/src/main/java/com/sparta/mypet/MypetApplication.java
@@ -4,14 +4,16 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
 @EnableFeignClients
 @SpringBootApplication
+@EnableScheduling
 public class MypetApplication {
 
-    public static void main(String[] args) {
-        SpringApplication.run(MypetApplication.class, args);
-    }
+	public static void main(String[] args) {
+		SpringApplication.run(MypetApplication.class, args);
+	}
 
 }

--- a/src/main/java/com/sparta/mypet/common/entity/GlobalMessage.java
+++ b/src/main/java/com/sparta/mypet/common/entity/GlobalMessage.java
@@ -47,6 +47,7 @@ public enum GlobalMessage {
 	USER_STATUS_DUPLICATE("현재 상태와 같습니다."),
 	USER_ROLE_DUPLICATE("현재 역할와 같습니다."),
 	SOCIAL_LINKED("소셜 계정이 연결되어있습니다."),
+	USER_REACTIVE_FAIL("해당 유저 정상화에 실패했습니다."),
 
 	// Post
 	POST_NOT_FOUND("존재하지 않는 게시물입니다."),

--- a/src/main/java/com/sparta/mypet/common/schedule/UserSchedule.java
+++ b/src/main/java/com/sparta/mypet/common/schedule/UserSchedule.java
@@ -1,0 +1,41 @@
+package com.sparta.mypet.common.schedule;
+
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sparta.mypet.common.entity.GlobalMessage;
+import com.sparta.mypet.common.exception.custom.UserNotFoundException;
+import com.sparta.mypet.domain.auth.UserService;
+import com.sparta.mypet.domain.auth.entity.User;
+import com.sparta.mypet.domain.auth.entity.UserStatus;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j(topic = "Scheduler")
+@Component
+@RequiredArgsConstructor
+public class UserSchedule {
+
+	private final UserService userService;
+
+	@Scheduled(cron = "0 0 0 * * *") //매일 자정에 실행
+	//@Scheduled(cron = "*/60 * * * * *") 테스트용 1분짜리
+	@Transactional
+	public void updateUserActive() {
+		log.info("유저 정상화 시작");
+		List<User> userList = userService.findExpiredSuspendedUsers();
+
+		for (User user : userList) {
+			try {
+				user.updateUserStatus(UserStatus.ACTIVE);
+			} catch (UserNotFoundException e) {
+				log.error(user.getId() + " : " + GlobalMessage.USER_REACTIVE_FAIL.getMessage());
+			}
+		}
+
+	}
+}

--- a/src/main/java/com/sparta/mypet/domain/auth/UserRepository.java
+++ b/src/main/java/com/sparta/mypet/domain/auth/UserRepository.java
@@ -1,8 +1,10 @@
 package com.sparta.mypet.domain.auth;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.sparta.mypet.domain.auth.entity.User;
@@ -10,4 +12,15 @@ import com.sparta.mypet.domain.auth.entity.User;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByEmail(String email);
+
+	@Query(value = "SELECT u.* " +
+		"FROM users u " +
+		"LEFT OUTER JOIN (" +
+		"    SELECT user_id, MAX(suspension_end_datetime) AS end_date " +
+		"    FROM suspensions " +
+		"    GROUP BY user_id" +
+		") s ON u.user_id = s.user_id " +
+		"WHERE u.status = 'SUSPENSION' " +
+		"AND s.end_date < NOW()", nativeQuery = true)
+	List<User> findExpiredSuspendedUsers();
 }

--- a/src/main/java/com/sparta/mypet/domain/auth/UserService.java
+++ b/src/main/java/com/sparta/mypet/domain/auth/UserService.java
@@ -206,4 +206,8 @@ public class UserService {
 
 		return query.getResultList();
 	}
+
+	public List<User> findExpiredSuspendedUsers() {
+		return userRepository.findExpiredSuspendedUsers();
+	}
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#135 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

매일 자정 suspension 상태의 유저의 suspensions 테이블 중 가장 max의 enddate가 도달 혹은 지난 경우 유저의 상태를 다시 ACTIVE 상태로 돌려놓는 schedule 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
