### PR TITLE
[2024/08/07]fix/#137-remove-refresh-token-claim

### DIFF
--- a/src/main/java/com/sparta/mypet/domain/auth/AuthService.java
+++ b/src/main/java/com/sparta/mypet/domain/auth/AuthService.java
@@ -13,7 +13,6 @@ import com.sparta.mypet.domain.auth.dto.LoginResponseDto;
 import com.sparta.mypet.domain.auth.entity.User;
 import com.sparta.mypet.domain.auth.entity.UserStatus;
 import com.sparta.mypet.security.JwtService;
-import com.sparta.mypet.security.TokenType;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -44,17 +43,15 @@ public class AuthService {
 			throw new UserStatusNotActiveException(GlobalMessage.USER_STATUS_STOP);
 		}
 
-		String accessToken = jwtService.generateToken(TokenType.ACCESS, user.getRole(), user.getEmail());
-		String refreshToken = jwtService.generateToken(TokenType.REFRESH, user.getRole(), user.getEmail());
+		String accessToken = jwtService.generateAccessToken(user.getRole(), user.getEmail());
+		String refreshToken = jwtService.generateRefreshToken(user.getEmail());
 
 		user.updateRefreshToken(refreshToken);
 
 		jwtService.setRefreshTokenAtCookie(refreshToken);
 		jwtService.setAccessTokenAtHeader(accessToken);
 
-		return LoginResponseDto.builder()
-			.user(user)
-			.build();
+		return LoginResponseDto.builder().user(user).build();
 	}
 
 	@Transactional
@@ -85,10 +82,8 @@ public class AuthService {
 			throw new RefreshTokenInvalidException(GlobalMessage.REFRESH_INVALID);
 		}
 
-		Object role = jwtService.extractRole(refreshToken);
-
-		String newAccessToken = jwtService.generateToken(TokenType.ACCESS, role, email);
-		String newRefreshToken = jwtService.generateToken(TokenType.REFRESH, role, email);
+		String newAccessToken = jwtService.generateAccessToken(user.getRole(), user.getEmail());
+		String newRefreshToken = jwtService.generateRefreshToken(user.getEmail());
 
 		user.updateRefreshToken(newRefreshToken);
 

--- a/src/main/java/com/sparta/mypet/domain/oauth/KakaoAccountService.java
+++ b/src/main/java/com/sparta/mypet/domain/oauth/KakaoAccountService.java
@@ -30,7 +30,6 @@ import com.sparta.mypet.domain.oauth.entity.SocialAccountInfo;
 import com.sparta.mypet.domain.oauth.entity.SocialAccountLeaveRequest;
 import com.sparta.mypet.domain.oauth.entity.SocialType;
 import com.sparta.mypet.security.JwtService;
-import com.sparta.mypet.security.TokenType;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -213,8 +212,8 @@ public class KakaoAccountService {
 			throw new UserEmailDuplicateException(GlobalMessage.EMAIL_ALREADY_USED.getMessage());
 		}
 
-		String accessToken = jwtService.generateToken(TokenType.ACCESS, user.getRole(), user.getEmail());
-		String refreshToken = jwtService.generateToken(TokenType.REFRESH, user.getRole(), user.getEmail());
+		String accessToken = jwtService.generateAccessToken(user.getRole(), user.getEmail());
+		String refreshToken = jwtService.generateRefreshToken(user.getEmail());
 
 		user.updateRefreshToken(refreshToken);
 

--- a/src/main/java/com/sparta/mypet/security/JwtService.java
+++ b/src/main/java/com/sparta/mypet/security/JwtService.java
@@ -39,17 +39,24 @@ public class JwtService {
 	private Long refreshTokenExpiration; // refresh token 만료 시간
 
 	/**
-	 * JWT 토큰을 생성합니다.
-	 * @param tokenType 토큰의 종류 (access, refresh)
+	 * JWT Access 토큰을 생성합니다.
 	 * @param role 유저의 역할 ("ROLE_USER", "ROLE_ADMIN", "ROLE_MANAGER")
 	 * @param username 유저의 식별자 (여기서는 Email)
-	 * @return 생성된 JWT 토큰
+	 * @return 생성된 JWT Access 토큰
 	 */
-	public String generateToken(TokenType tokenType, Object role, String username) {
-		long expiration = (tokenType.equals(TokenType.ACCESS)) ? accessTokenExpiration : refreshTokenExpiration;
-
-		return JwtProvider.generateToken(AUTHORIZATION_KEY, role, username, expiration,
+	public String generateAccessToken(Object role, String username) {
+		return JwtProvider.generateAccessToken(AUTHORIZATION_KEY, role, username, accessTokenExpiration,
 			JwtProvider.getSecretKey(secretKey), SIGNATURE_ALGORITHM);
+	}
+
+	/**
+	 * JWT Refresh 토큰을 생성합니다.
+	 * @param username 유저의 식별자 (여기서는 Email)
+	 * @return 생성된 JWT Refresh 토큰
+	 */
+	public String generateRefreshToken(String username) {
+		return JwtProvider.generateRefreshToken(username, refreshTokenExpiration, JwtProvider.getSecretKey(secretKey),
+			SIGNATURE_ALGORITHM);
 	}
 
 	/**
@@ -161,15 +168,6 @@ public class JwtService {
 	 */
 	public String extractEmail(String token) {
 		return JwtProvider.extractAllClaims(token, JwtProvider.getSecretKey(secretKey)).getSubject();
-	}
-
-	/**
-	 * JWT 토큰에서 권한을 추출합니다.
-	 * @param token JWT 토큰
-	 * @return 추출된 User Role
-	 */
-	public Object extractRole(String token) {
-		return JwtProvider.extractAllClaims(token, JwtProvider.getSecretKey(secretKey)).get(AUTHORIZATION_KEY);
 	}
 
 	/**

--- a/src/main/java/com/sparta/mypet/security/TokenType.java
+++ b/src/main/java/com/sparta/mypet/security/TokenType.java
@@ -1,6 +1,0 @@
-package com.sparta.mypet.security;
-
-public enum TokenType {
-	ACCESS,
-	REFRESH
-}

--- a/src/main/java/com/sparta/mypet/security/util/JwtProvider.java
+++ b/src/main/java/com/sparta/mypet/security/util/JwtProvider.java
@@ -17,20 +17,39 @@ public final class JwtProvider {
 	}
 
 	/**
-	 * JWT 토큰 생성
+	 * JWT Access Token 생성
 	 * @param authorizationKey 역할 정보가 저장될 클레임 키
 	 * @param role 사용자 역할
 	 * @param username 사용자 이름(여기서는 Email)
 	 * @param expiration 토큰 만료 시간 (밀리초)
 	 * @param secretKey 토큰 서명을 위한 비밀 키
 	 * @param signatureAlgorithm 토큰 서명 알고리즘
-	 * @return 생성된 JWT 토큰
+	 * @return 생성된 JWT Access Token
 	 */
-	public static String generateToken(String authorizationKey, Object role, String username, long expiration,
+	public static String generateAccessToken(String authorizationKey, Object role, String username, long expiration,
 		SecretKey secretKey, SignatureAlgorithm signatureAlgorithm) {
 
 		return Jwts.builder()
 			.claim(authorizationKey, role)
+			.setSubject(username)
+			.setIssuedAt(new Date(System.currentTimeMillis()))
+			.setExpiration(new Date(System.currentTimeMillis() + expiration))
+			.signWith(secretKey, signatureAlgorithm)
+			.compact();
+	}
+
+	/**
+	 * JWT Refresh Token 생성
+	 * @param username 사용자 이름(여기서는 Email)
+	 * @param expiration 토큰 만료 시간 (밀리초)
+	 * @param secretKey 토큰 서명을 위한 비밀 키
+	 * @param signatureAlgorithm 토큰 서명 알고리즘
+	 * @return 생성된 JWT Refresh Token
+	 */
+	public static String generateRefreshToken(String username, long expiration, SecretKey secretKey,
+		SignatureAlgorithm signatureAlgorithm) {
+
+		return Jwts.builder()
 			.setSubject(username)
 			.setIssuedAt(new Date(System.currentTimeMillis()))
 			.setExpiration(new Date(System.currentTimeMillis() + expiration))


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#137 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 리프레쉬 토큰을 생성부분에서 Claim 제거
- 엑세스 토큰과 리프레쉬 토큰 로직 분리
- 연관된 `AuthService`, `KakaoAccountService` 수정
- 로직 분리로 더 이상 사용되지 않는 TokenType Enum 삭제

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

@lis0517 윤성님 확인 부탁드려요! 관련 부분 수정됬습니다.
