### PR TITLE
[2024/08/12]feat/#163 user repository querydsl

### DIFF
--- a/src/main/java/com/sparta/mypet/domain/auth/UserRepository.java
+++ b/src/main/java/com/sparta/mypet/domain/auth/UserRepository.java
@@ -1,10 +1,8 @@
 package com.sparta.mypet.domain.auth;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.sparta.mypet.domain.auth.entity.User;
@@ -12,15 +10,4 @@ import com.sparta.mypet.domain.auth.entity.User;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryQuery {
 	Optional<User> findByEmail(String email);
-
-	@Query(value = "SELECT u.* " +
-		"FROM users u " +
-		"LEFT OUTER JOIN (" +
-		"    SELECT user_id, MAX(suspension_end_datetime) AS end_date " +
-		"    FROM suspensions " +
-		"    GROUP BY user_id" +
-		") s ON u.user_id = s.user_id " +
-		"WHERE u.status = 'SUSPENSION' " +
-		"AND s.end_date < NOW()", nativeQuery = true)
-	List<User> findExpiredSuspendedUsers();
 }

--- a/src/main/java/com/sparta/mypet/domain/auth/UserRepositoryQuery.java
+++ b/src/main/java/com/sparta/mypet/domain/auth/UserRepositoryQuery.java
@@ -1,5 +1,7 @@
 package com.sparta.mypet.domain.auth;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -8,4 +10,6 @@ import com.sparta.mypet.domain.auth.entity.UserSearchCondition;
 
 public interface UserRepositoryQuery {
 	Page<User> findBySearchCond(UserSearchCondition searchCondition, Pageable pageable);
+
+	List<User> findExpiredSuspendedUsers();
 }

--- a/src/main/java/com/sparta/mypet/domain/auth/UserRepositoryQueryImpl.java
+++ b/src/main/java/com/sparta/mypet/domain/auth/UserRepositoryQueryImpl.java
@@ -2,6 +2,7 @@ package com.sparta.mypet.domain.auth;
 
 import static com.sparta.mypet.domain.auth.entity.QUser.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
@@ -11,11 +12,14 @@ import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.mypet.domain.auth.entity.QUser;
 import com.sparta.mypet.domain.auth.entity.User;
 import com.sparta.mypet.domain.auth.entity.UserRole;
 import com.sparta.mypet.domain.auth.entity.UserSearchCondition;
 import com.sparta.mypet.domain.auth.entity.UserStatus;
+import com.sparta.mypet.domain.suspension.entity.QSuspension;
 
 import lombok.RequiredArgsConstructor;
 
@@ -58,5 +62,24 @@ public class UserRepositoryQueryImpl implements UserRepositoryQuery {
 
 	private BooleanExpression eqEmail(String email) {
 		return StringUtils.hasText(email) ? user.email.containsIgnoreCase(email) : null;
+	}
+
+	@Override
+	public List<User> findExpiredSuspendedUsers() {
+		QUser user = QUser.user;
+		QSuspension suspension = QSuspension.suspension;
+
+		return queryFactory.select(user)
+			.from(user)
+			.innerJoin(suspension)
+			.on(user.id.eq(suspension.user.id)
+				.and(suspension.suspensionEndDatetime.eq(
+					JPAExpressions.select(suspension.suspensionEndDatetime.max())
+						.from(suspension)
+						.where(suspension.user.id.eq(user.id))
+				)))
+			.where(user.status.eq(UserStatus.SUSPENSION)
+				.and(suspension.suspensionEndDatetime.before(LocalDateTime.now())))
+			.fetch();
 	}
 }

--- a/src/main/java/com/sparta/mypet/domain/auth/entity/User.java
+++ b/src/main/java/com/sparta/mypet/domain/auth/entity/User.java
@@ -55,12 +55,11 @@ public class User extends Timestamped {
 	@Column(nullable = false)
 	private UserStatus status;
 
-	@OneToMany(mappedBy = "user", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
 	private final List<Post> postList = new ArrayList<>();
 
 	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
 	private final List<SocialAccount> socialAccounts = new ArrayList<>();
-
 
 	@Builder
 	public User(String email, String password, String nickname, Integer suspensionCount, UserRole role,


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#163 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

JQPL로 구현되어 있는 `findExpiredSuspendedUsers()` 메서드를 QueryDsl로 변경

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

서브쿼리를 최대한 쓰지 않고 구현해보려고 이것저것 최대한 시도 해봤지만, 결국 못해서 사용했습니다...ㅠㅠ
제가 서브쿼리를 안쓰고 구현하는 방법으로는 결국 쿼리가 2번 발생하게 되기 때문에, 그것 보다는 서브쿼리 쓰는게 낫다고 판단해서 서브쿼리를 사용해서 구현했습니다.
